### PR TITLE
Feat: auto detect go version; Use soft coding instead of hard coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ systemctl disable --now sing-box && rm -f /usr/local/bin/sing-box /root/sing-box
 ### Android 使用方法：
 
 1. 下载Android客户端程序[SFA-arm64-v8a.apk](https://github.com/SagerNet/sing-box/releases)。
-3. 参考[客户端配置](https://github.com/chika0801/sing-box-examples/blob/main/Tun/config_client_android.json)示例，按需修改后导入。
+3. 参考[客户端配置](Tun/config_client_android.json)示例，按需修改后导入。
 
 ### Windows 使用方法：
 
 1. 下载Windows客户端程序[sing-box-windows-amd64.zip](https://github.com/SagerNet/sing-box/releases)。
 2. 新建一个批处理文件，内容为 `start /min sing-box.exe run`。
-3. 参考[客户端配置](https://github.com/chika0801/sing-box-examples/blob/main/Tun/config_client_windows.json)示例，按需修改后将文件名改为 **config.json**，与 **sing-box.exe**，批处理文件放在同一文件夹里。
+3. 参考[客户端配置](Tun/config_client_windows.json)示例，按需修改后将文件名改为 **config.json**，与 **sing-box.exe**，批处理文件放在同一文件夹里。
 4. 右键点击 **sing-box.exe** 选择属性，选择兼容性，选择以管理员身份运行此程序，确定。
 5. 运行批处理文件，在弹出的用户账户控制对话框中，选择是。

--- a/compile_sing-box.md
+++ b/compile_sing-box.md
@@ -1,7 +1,7 @@
 准备环境
 
 ```
-curl -sLo go.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
+curl -L https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text|head -1).linux-amd64.tar.gz >> go.tar.gz
 rm -rf /usr/local/go
 tar -C /usr/local -xzf go.tar.gz
 rm go.tar.gz


### PR DESCRIPTION
使用 `curl -sL https://golang.org/VERSION?m=text|head -1` 智能更新go版本
https://github.com/chika0801/sing-box-examples/commit/54063d0a7d408a8ca3343f89062e975c8fde7321
顺便改了两个硬编码为软编码，让fork的仓库不会重新指向这个仓库
https://github.com/chika0801/sing-box-examples/commit/f1d5844eb7472729a55269e1c5cd91402b2ebb86