### PR TITLE
使用魔法自动获取下载的name

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ bash -c "$(curl -L https://sing-box.vercel.app)" @ remove
 1. 下载程序（**linux-amd64**）或 [编译程序](compile_sing-box.md)
 
 ```
-curl -Lo sing-box.tar.gz https://github.com/SagerNet/sing-box/releases/download/v1.6.4/sing-box-1.6.4-linux-amd64.tar.gz && tar -xzf sing-box.tar.gz && cp -f sing-box-*/sing-box . && rm -r sing-box.tar.gz sing-box-* && chown root:root sing-box && chmod +x sing-box && mv -f sing-box /usr/local/bin/
+curl -Lo sing-box.tar.gz https://github.com/SagerNet/sing-box/releases/latest/download/$(curl https://api.github.com/repos/SagerNet/sing-box/releases|grep -E '"name": "sing-box-.*-linux-amd64.tar.gz"'|grep -Pv '(alpha|beta|rc)'|sed -n 's/.*"name": "\(.*\)".*/\1/p'|head -1) && tar -xzf sing-box.tar.gz && cp -f sing-box-*/sing-box . && rm -r sing-box.tar.gz sing-box-* && chown root:root sing-box && chmod +x sing-box && mv -f sing-box /usr/local/bin/
 ```
 
 2. 上传配置、证书和私钥


### PR DESCRIPTION
不过有点长，但是可以减少因为没有及时更新readme导致的版本落后。
其中```|grep -Pv '(alpha|beta|rc)' ```是过滤pre-release版本号，对应latest不会包括pre-release。
如果用户提前安装了 `jq` 那就简单了：```jq -r '.name'```， ~~不过似乎也没那么简单，因为还有一长串url~~ 